### PR TITLE
added fix for string replace of package path of "." to "/". Previous code was only replacing first occurrence of ".", so was failing

### DIFF
--- a/app/sdk-versions.js
+++ b/app/sdk-versions.js
@@ -9,8 +9,8 @@ module.exports = {
     supportedJavaVersions: '^1.8.0',
     supportedMavenVersions: '^3.2.5',
     removeSamplesScript: function() {
-      var projectPackagePath = this.projectPackage.replace('.', '/');
-      [ 
+      var projectPackagePath = this.projectPackage.replace(/\./g, '/');
+      [
         'repo-amp/src/main/amp/web/css/demoamp.css',
         'repo-amp/src/main/amp/web/jsp/demoamp.jsp',
         'repo-amp/src/main/amp/web/scripts/demoamp.js',
@@ -44,7 +44,7 @@ module.exports = {
         this.fs.delete(file, {globOptions: {strict: true}});
       }.bind(this));
 
-      [ 
+      [
         'repo-amp/src/main/amp/config/alfresco/extension/templates/webscripts/EMPTY.txt',
         'repo-amp/src/main/java/EMPTY.txt',
         'repo-amp/src/test/java/EMPTY.txt',
@@ -60,7 +60,7 @@ module.exports = {
       var moduleContextPath = 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/module-context.xml';
       var contextDocOrig = this.fs.read(this.destinationPath(moduleContextPath));
       var context = require('./spring-context.js')(contextDocOrig);
-      [ 
+      [
         'classpath:alfresco/module/${project.artifactId}/context/service-context.xml',
         'classpath:alfresco/module/${project.artifactId}/context/bootstrap-context.xml',
         'classpath:alfresco/module/${project.artifactId}/context/webscript-context.xml',

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -7,74 +7,111 @@ var os = require('os');
 
 describe('generator-alfresco:app', function () {
 
-  this.timeout(60000);
+  describe('default prompts', function () {
 
-  before(function (done) {
-    helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(os.tmpdir(), './temp-test'))
-      .withOptions({ 'skip-install': true })
-      .withPrompts({
-      })
-      .on('end', done);
+    this.timeout(60000);
+
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(os.tmpdir(), './temp-test'))
+        .withOptions({ 'skip-install': true })
+        .withPrompts({
+        })
+        .on('end', done);
+    });
+
+    it('creates files', function () {
+      // TODO(bwavell): add more tests
+      assert.file([
+        '.editorconfig',
+        '.gitignore',
+        '.yo-rc.json',
+        'pom.xml',
+        'run.sh',
+        'scripts/debug.sh',
+        'scripts/env.sh',
+        'scripts/explode-alf-sources.sh',
+        'scripts/find-exploded.sh',
+        'scripts/grep-exploded.sh',
+        'scripts/package-to-exploded.sh',
+        'scripts/run.sh',
+        'amps/README.md',
+        'amps_share/README.md',
+        'amps_source/README.md',
+        'amps_source_templates/README.md',
+        'amps_source_templates/repo-amp/pom.xml',
+        'amps_source_templates/share-amp/pom.xml',
+        'repo/pom.xml',
+        'repo-amp/pom.xml',
+        'runner/pom.xml',
+        'share/pom.xml',
+        'share-amp/pom.xml',
+        'solr-config/pom.xml',
+        'TODO.md',
+        'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/README.md',
+        'repo-amp/src/main/amp/config/alfresco/extension/templates/webscripts/EMPTY.txt',
+      ]);
+    });
+    it('adds generic include for generated beans', function () {
+      assert.fileContent(
+        'repo-amp/src/main/amp/config/alfresco/module/repo-amp/module-context.xml',
+        /<import resource="classpath:alfresco\/module\/\${project\.artifactId}\/context\/generated\/\*-context\.xml"\/>/
+      );
+    });
+    it('does not create enterprise specific files', function () {
+      assert.noFile([
+        'repo/src/main/resources/alfresco/extension/license/README.md',
+      ]);
+    });
+    it('removes demo files', function () {
+      assert.noFile([
+        // This list is representative, it is not a complete list of items that are removed
+        'repo-amp/src/main/java/org/alfresco/demoamp/Demo.java',
+        'repo-amp/src/test/java/org/alfresco/demoamp/test/DemoComponentTest.java',
+      ]);
+    });
+    it('run.sh and debug.sh should not include -Penterprise flag', function () {
+      assert.noFileContent([
+        ['run.sh', /-Penterprise/],
+        ['scripts/debug.sh', /-Penterprise/],
+        ['scripts/run.sh', /-Penterprise/]
+      ]);
+    });
   });
 
-  it('creates files', function () {
-    // TODO(bwavell): add more tests
-    assert.file([
-      '.editorconfig',
-      '.gitignore',
-      '.yo-rc.json',
-      'pom.xml',
-      'run.sh',
-      'scripts/debug.sh',
-      'scripts/env.sh',
-      'scripts/explode-alf-sources.sh',
-      'scripts/find-exploded.sh',
-      'scripts/grep-exploded.sh',
-      'scripts/package-to-exploded.sh',
-      'scripts/run.sh',
-      'amps/README.md',
-      'amps_share/README.md',
-      'amps_source/README.md',
-      'amps_source_templates/README.md',
-      'amps_source_templates/repo-amp/pom.xml',
-      'amps_source_templates/share-amp/pom.xml',
-      'repo/pom.xml',
-      'repo-amp/pom.xml',
-      'runner/pom.xml',
-      'share/pom.xml',
-      'share-amp/pom.xml',
-      'solr-config/pom.xml',
-      'TODO.md',
-      'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/README.md',
-      'repo-amp/src/main/amp/config/alfresco/extension/templates/webscripts/EMPTY.txt',
-    ]);
+  describe('projectPackage foo.bar.baz', function () {
+
+    this.timeout(60000);
+
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(os.tmpdir(), './temp-test'))
+        .withOptions({ 'skip-install': true })
+        .withPrompts({
+          sdkVersion: '2.1.0',
+          projectGroupId: 'org.alfresco',
+          projectArtifactId: 'demoamp',
+          projectVersion: '1.0.0-SNAPSHOT',
+          projectPackage: 'foo.bar.baz',
+          communityOrEnterprise: 'Community',
+          includeGitIgnore: true,
+          removeSamples: true,
+        })
+        .on('end', done);
+    });
+
+    it('removes package based demo files', function () {
+      assert.noFile([
+        'repo-amp/src/main/java/foo/bar/baz/demoamp/Demo.java',
+        'repo-amp/src/test/java/foo/bar/baz/demoamp/test/DemoComponentTest.java',
+        'repo-amp/src/main/java/foo/bar/baz/demoamp/HelloWorldWebScript.java',
+        'repo-amp/src/main/java/foo/bar/baz/demoamp',
+        'repo-amp/src/test/java/foo/bar/baz/demoamp/test/DemoComponentTest.java',
+        'repo-amp/src/test/java/foo/bar/baz/demoamp'
+      ]);
+    });
   });
-  it('adds generic include for generated beans', function () {
-    assert.fileContent(
-      'repo-amp/src/main/amp/config/alfresco/module/repo-amp/module-context.xml',
-      /<import resource="classpath:alfresco\/module\/\${project\.artifactId}\/context\/generated\/\*-context\.xml"\/>/
-    );
-  });
-  it('does not create enterprise specific files', function () {
-    assert.noFile([
-      'repo/src/main/resources/alfresco/extension/license/README.md',
-    ]);
-  });
-  it('removes demo files', function () {
-    assert.noFile([
-      // This list is representative, it is not a complete list of items that are removed
-      'repo-amp/src/main/java/org/alfresco/demoamp/Demo.java',
-      'repo-amp/src/test/java/org/alfresco/demoamp/test/DemoComponentTest.java',
-    ]);
-  });
-  it('run.sh and debug.sh should not include -Penterprise flag', function () {
-    assert.noFileContent([
-      ['run.sh', /-Penterprise/],
-      ['scripts/debug.sh', /-Penterprise/],
-      ['scripts/run.sh', /-Penterprise/]
-    ]);
-  });
+
 });
 
 // vim: autoindent expandtab tabstop=2 shiftwidth=2 softtabstop=2


### PR DESCRIPTION
added fix for string replace of package path of "." to "/". Previous code was only replacing first occurrence of ".", so was failing on multiple occurrences (e.g. foo.bar.baz would be replaced with foo/bar.baz).
