### PR TITLE
Feature travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jdk:
 env:
   - NODE_VERSION=0.10
   - NODE_VERSION=0.12
-  - NODE_VERSION=4.1
+  - NODE_VERSION=4.2
+  - NODE_VERSION=5.1
 
 install:
   - nvm install $NODE_VERSION

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cross-spawn": "2.1.5",
     "deasync": "0.1.4",
     "eyes": "0.1.8",
-    "lodash": "4.6.0",
+    "lodash": "4.6.1",
     "pretty-data": "0.40.0",
     "rmdir": "1.2.0",
     "semver": "5.1.0",
@@ -41,14 +41,14 @@
     "yosay": "1.1.0"
   },
   "devDependencies": {
-    "coveralls": "2.11.8",
+    "coveralls": "2.11.9",
     "fixme": "0.3.0",
     "istanbul": "0.4.2",
     "mem-fs": "1.1.2",
     "mem-fs-editor": "2.2.0",
     "mocha": "2.4.5",
     "mocha-lcov-reporter": "1.2.0",
-    "npm-check-updates": "2.5.8",
+    "npm-check-updates": "2.6.1",
     "shelljs": "0.5.0",
     "yeoman-assert": "2.1.1",
     "yeoman-test": "1.1.0"


### PR DESCRIPTION
Updated node versions we test against and also updated a few deps. It appears shell.js 0.6.0 is not compatible with node 0.10, so sticking with shell.js 0.5.0 for now.
