### PR TITLE
create default run.sh which prompts

### DIFF
--- a/generators/common/sdk-versions.js
+++ b/generators/common/sdk-versions.js
@@ -375,7 +375,11 @@ function removeShareSamples (pathPrefix, projectPackage, artifactIdPrefix) {
 function beforeExit () {
   if (this.config.get(constants.PROP_ARCHETYPE_VERSION)) {
     if (semver.satisfies(semver.clean(this.config.get(constants.PROP_ARCHETYPE_VERSION)), '>=2.2.0-SNAPSHOT')) {
-      fs.unlinkSync(this.destinationPath(constants.FILE_RUN_SH));
+      fs.writeFileSync(this.destinationPath(constants.FILE_RUN_SH), [
+        '#!/bin/bash',
+        'echo WARNING: This version of the SDK does not support spring-loaded.',
+        'echo WARNING: Please use: run-without-springloaded.sh instead of run.sh.',
+      ].join('\n'));
       fs.unlinkSync(this.destinationPath(path.join(constants.FOLDER_SCRIPTS, constants.FILE_RUN_SH)));
     }
   }


### PR DESCRIPTION
@vprince1 already did most of the work on this, I just patched up the final issue blocking us closing #44. Which was that for some reason (do we blame @mmuller? 😀) the 2.2.0 SDK tries to make run.sh executable and since we were previously deleting it we could not start the project. Instead of deleting run.sh from the top folder, this replaces it with a script that tells folks to use run-without-spring-loaded.sh instead.

resolves #44
