### PR TITLE
can now use action, also actions are localized

### DIFF
--- a/generators/action/index.js
+++ b/generators/action/index.js
@@ -93,16 +93,16 @@ module.exports = SourceSelectingSubGenerator.extend({
 
       var classSrc = this.templatePath('ActionExecuter.java');
       var contextSrc = this.templatePath('action-context.xml');
-      var propertiesSrc = this.templatePath('action.properties');
+      var messagesSrc = this.templatePath('action.properties');
 
       var packagePath = _.replace(packageName, /\./g, '/');
       var classDst = path.join(moduleRoot, 'src/main/java', packagePath, className + '.java');
       var contextDst = path.join(moduleRoot, genRoot, 'action-' + actionId + '-context.xml');
-      var propertiesDst = path.join(moduleRoot, msgRoot, artifactId + '-' + actionId + '-action.properties');
+      var messagesDst = path.join(moduleRoot, msgRoot, artifactId + '-' + actionId + '-action.properties');
 
       this.fs.copyTpl(classSrc, classDst, templateContext);
       this.fs.copyTpl(contextSrc, contextDst, templateContext);
-      this.fs.copyTpl(propertiesSrc, propertiesDst, templateContext);
+      this.fs.copyTpl(messagesSrc, messagesDst, templateContext);
 
       debug('prompting done function finished');
     }.bind(this));

--- a/generators/action/templates/ActionExecuter.java
+++ b/generators/action/templates/ActionExecuter.java
@@ -27,16 +27,16 @@ import java.util.List;
  * aParams.put(<%- className %>.PARAM_ONE, "Document");
  * aParams.put(<%- className %>.PARAM_TWO, "Example");
  *
- * Action action = actionService.createAction("<%- artifactId %>-<%- actionId %>", aParams);
+ * Action action = actionService.createAction("<%- artifactId %>.<%- actionId %>", aParams);
  * if (action != null) {
  *   actionService.executeAction(action, docNodeRef, checkConditions, executeAsync);
  * } else {
- *   throw new RuntimeException("Could not create <%- artifactId %>-<%- actionId %> action");
+ *   throw new RuntimeException("Could not create <%- artifactId %>.<%- actionId %> action");
  * }
  * ```
  *
  * ```javascript
- * var myAction = actions.create('<%- artifactId %>-<%- actionId %>');
+ * var myAction = actions.create('<%- artifactId %>.<%- actionId %>');
  * myAction.parameters['one'] = 'Document';
  * myAction.parameters['two'] = 'Example';
  * myAction.execute(document);
@@ -45,7 +45,7 @@ import java.util.List;
 public class <%- className %> extends ActionExecuterAbstractBase {
   private static Log logger = LogFactory.getLog(<%- className %>.class);
 
-  public static final String ACTION_NAME = "<%- artifactId %>-<%- actionId %>";
+  public static final String ACTION_NAME = "<%- artifactId %>.<%- actionId %>";
   public static final String PARAM_ONE = "one";
   public static final String PARAM_TWO = "two";
 

--- a/generators/action/templates/ActionExecuter.java
+++ b/generators/action/templates/ActionExecuter.java
@@ -27,16 +27,16 @@ import java.util.List;
  * aParams.put(<%- className %>.PARAM_ONE, "Document");
  * aParams.put(<%- className %>.PARAM_TWO, "Example");
  *
- * Action action = actionService.createAction("<%- actionId %>", aParams);
+ * Action action = actionService.createAction("<%- artifactId %>-<%- actionId %>", aParams);
  * if (action != null) {
  *   actionService.executeAction(action, docNodeRef, checkConditions, executeAsync);
  * } else {
- *   throw new RuntimeException("Could not create <%- actionId %> action");
+ *   throw new RuntimeException("Could not create <%- artifactId %>-<%- actionId %> action");
  * }
  * ```
  *
  * ```javascript
- * var myAction = actions.create('<%- actionId %>');
+ * var myAction = actions.create('<%- artifactId %>-<%- actionId %>');
  * myAction.parameters['one'] = 'Document';
  * myAction.parameters['two'] = 'Example';
  * myAction.execute(document);
@@ -45,7 +45,7 @@ import java.util.List;
 public class <%- className %> extends ActionExecuterAbstractBase {
   private static Log logger = LogFactory.getLog(<%- className %>.class);
 
-  public static final String ACTION_NAME = "<%- actionId %>";
+  public static final String ACTION_NAME = "<%- artifactId %>-<%- actionId %>";
   public static final String PARAM_ONE = "one";
   public static final String PARAM_TWO = "two";
 
@@ -66,15 +66,5 @@ public class <%- className %> extends ActionExecuterAbstractBase {
     if (serviceRegistry.getNodeService().exists(actionedUponNodeRef) == true) {
       logger.info("<%- className %> is processing: " + actionedUponNodeRef.toString());
     }
-  }
-
-  /**
-   * By default Alfresco will use the bean name as the action name.
-   * We like to namespace qualify our beans, so this is how we make
-   * Alfresco use the unqualified name for our action.
-   */
-  @Override
-  public void setBeanName(String name) {
-    super.setBeanName(ACTION_NAME);
   }
 }

--- a/generators/action/templates/action-context.xml
+++ b/generators/action/templates/action-context.xml
@@ -3,9 +3,18 @@
 
 <beans>
 
-    <!-- Registration of new action -->
-    <bean id="${artifactId}.<%- actionId %>" class="<%- packageName %>.<%- className %>" parent="action-executer">
-      <property name="serviceRegistry" ref="ServiceRegistry" />
-    </bean>
+  <!-- Registration of action -->
+  <bean id="<%- artifactId %>-<%- actionId %>" class="<%- packageName %>.<%- className %>" parent="action-executer">
+    <property name="serviceRegistry" ref="ServiceRegistry" />
+  </bean>
+
+  <!-- Register bundle with labels for action -->
+  <bean id="<%- artifactId %>-<%- actionId %>-action-properties" class="org.alfresco.i18n.ResourceBundleBootstrapComponent">
+    <property name="resourceBundles">
+      <list>
+        <value>alfresco/module/${project.artifactId}/messages/<%- artifactId %>-<%- actionId %>-action</value>
+      </list>
+    </property>
+  </bean>
 
 </beans>

--- a/generators/action/templates/action-context.xml
+++ b/generators/action/templates/action-context.xml
@@ -4,12 +4,12 @@
 <beans>
 
   <!-- Registration of action -->
-  <bean id="<%- artifactId %>-<%- actionId %>" class="<%- packageName %>.<%- className %>" parent="action-executer">
+  <bean id="<%- artifactId %>.<%- actionId %>" class="<%- packageName %>.<%- className %>" parent="action-executer">
     <property name="serviceRegistry" ref="ServiceRegistry" />
   </bean>
 
   <!-- Register bundle with labels for action -->
-  <bean id="<%- artifactId %>-<%- actionId %>-action-properties" class="org.alfresco.i18n.ResourceBundleBootstrapComponent">
+  <bean id="<%- artifactId %>.<%- actionId %>-action-messages" class="org.alfresco.i18n.ResourceBundleBootstrapComponent">
     <property name="resourceBundles">
       <list>
         <value>alfresco/module/${project.artifactId}/messages/<%- artifactId %>-<%- actionId %>-action</value>

--- a/generators/action/templates/action.properties
+++ b/generators/action/templates/action.properties
@@ -1,0 +1,4 @@
+<%- artifactId %>-<%- actionId %>.title=<%- actionTitle %>
+<%- artifactId %>-<%- actionId %>.description=<%- actionDescription %>
+<%- artifactId %>-<%- actionId %>.one.display-label=First Param
+<%- artifactId %>-<%- actionId %>.two.display-label=Second Param

--- a/generators/action/templates/action.properties
+++ b/generators/action/templates/action.properties
@@ -1,4 +1,4 @@
-<%- artifactId %>-<%- actionId %>.title=<%- actionTitle %>
-<%- artifactId %>-<%- actionId %>.description=<%- actionDescription %>
-<%- artifactId %>-<%- actionId %>.one.display-label=First Param
-<%- artifactId %>-<%- actionId %>.two.display-label=Second Param
+<%- artifactId %>.<%- actionId %>.title=<%- actionTitle %>
+<%- artifactId %>.<%- actionId %>.description=<%- actionDescription %>
+<%- artifactId %>.<%- actionId %>.one.display-label=First Param
+<%- artifactId %>.<%- actionId %>.two.display-label=Second Param

--- a/test/test-action.js
+++ b/test/test-action.js
@@ -26,6 +26,7 @@ describe('generator-alfresco:action', function () {
     describe('when creating action with two word name', function () {
       var actionFile = path.join(osTempDir, 'repo-amp/src/main/java/org/alfresco/actions/TwoWordsActionExecuter.java');
       var contextFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/action-two-words-context.xml');
+      var messageFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/messages/repo-amp-two-words-action.properties');
 
       before(function (done) {
         helpers.run(path.join(__dirname, '../generators/action'))
@@ -47,6 +48,7 @@ describe('generator-alfresco:action', function () {
         assert.file([
           actionFile,
           contextFile,
+          messageFile,
         ]);
       });
 
@@ -61,7 +63,7 @@ describe('generator-alfresco:action', function () {
 
       it('has valid content in context file', function () {
         assert.fileContent([
-          [contextFile, /<bean id="\$\{artifactId}.two-words"/],
+          [contextFile, /<bean id="repo-amp.two-words"/],
           [contextFile, /class="org.alfresco.actions.TwoWordsActionExecuter/],
         ]);
       });
@@ -70,6 +72,7 @@ describe('generator-alfresco:action', function () {
     describe('when creating action with camel case name', function () {
       var actionFile = path.join(osTempDir, 'repo-amp/src/main/java/org/alfresco/actions/CamelCaseActionExecuter.java');
       var contextFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/action-camel-case-context.xml');
+      var messageFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/messages/repo-amp-camel-case-action.properties');
 
       before(function (done) {
         helpers.run(path.join(__dirname, '../generators/action'))
@@ -91,6 +94,7 @@ describe('generator-alfresco:action', function () {
         assert.file([
           actionFile,
           contextFile,
+          messageFile,
         ]);
       });
 
@@ -105,7 +109,7 @@ describe('generator-alfresco:action', function () {
 
       it('has valid content in context file', function () {
         assert.fileContent([
-          [contextFile, /<bean id="\$\{artifactId}.camel-case"/],
+          [contextFile, /<bean id="repo-amp.camel-case"/],
           [contextFile, /class="org.alfresco.actions.CamelCaseActionExecuter/],
         ]);
       });
@@ -114,6 +118,7 @@ describe('generator-alfresco:action', function () {
     describe('when creating action using package that does not end with .actions', function () {
       var actionFile = path.join(osTempDir, 'repo-amp/src/main/java/org/alfresco/actions/TestActionExecuter.java');
       var contextFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/action-test-context.xml');
+      var messageFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/messages/repo-amp-test-action.properties');
 
       before(function (done) {
         helpers.run(path.join(__dirname, '../generators/action'))
@@ -135,6 +140,7 @@ describe('generator-alfresco:action', function () {
         assert.file([
           actionFile,
           contextFile,
+          messageFile,
         ]);
       });
 
@@ -149,7 +155,7 @@ describe('generator-alfresco:action', function () {
 
       it('has valid content in context file', function () {
         assert.fileContent([
-          [contextFile, /<bean id="\$\{artifactId}.test"/],
+          [contextFile, /<bean id="repo-amp.test"/],
           [contextFile, /class="org.alfresco.actions.TestActionExecuter/],
         ]);
       });
@@ -158,6 +164,7 @@ describe('generator-alfresco:action', function () {
     describe('when creating action using prompts', function () {
       var actionFile = path.join(osTempDir, 'repo-amp/src/main/java/org/alfresco/actions/PromptsActionExecuter.java');
       var contextFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/action-prompts-context.xml');
+      var messageFile = path.join(osTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/messages/repo-amp-prompts-action.properties');
 
       before(function (done) {
         helpers.run(path.join(__dirname, '../generators/action'))
@@ -179,6 +186,7 @@ describe('generator-alfresco:action', function () {
         assert.file([
           actionFile,
           contextFile,
+          messageFile,
         ]);
       });
 
@@ -193,7 +201,7 @@ describe('generator-alfresco:action', function () {
 
       it('has valid content in context file', function () {
         assert.fileContent([
-          [contextFile, /<bean id="\$\{artifactId}.prompts"/],
+          [contextFile, /<bean id="repo-amp.prompts"/],
           [contextFile, /class="org.alfresco.actions.PromptsActionExecuter/],
         ]);
       });
@@ -217,9 +225,11 @@ describe('generator-alfresco:action', function () {
     it('does not create action files', function () {
       var actionFile = path.join(noProjectTempDir, 'repo-amp/src/main/java/org/alfresco/actions/NoProjectActionExecuter.java');
       var contextFile = path.join(noProjectTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/context/generated/action-no-project-context.xml');
+      var messageFile = path.join(noProjectTempDir, 'repo-amp/src/main/amp/config/alfresco/module/repo-amp/messages/repo-amp-no-project-action.properties');
       assert.noFile([
         actionFile,
         contextFile,
+        messageFile,
       ]);
     });
   });


### PR DESCRIPTION
fix issue where generated actions could be called but not used
- I was trying to namespace qualify the bean id without the action actually having a long name, that was dumb... so now the bean has a long name and so does the action...

per Jeff's valid observation a resource bundle should be provided with an action in order to provide a pretty name/title and description for the action and the associated parameters.
