### PR TITLE
Added overlays folder to .gitignore

### DIFF
--- a/generators/app/templates/gitignore
+++ b/generators/app/templates/gitignore
@@ -10,3 +10,4 @@
 target/
 alf_data_dev/
 exploded/
+overlays/


### PR DESCRIPTION
Pull request for issue #102.

I simply added the exclusion as I suggested in the issue. I'm not under the impression that the exclusion needs to be more specific, so I added it in the same fashion as `target/` and `exploded/`.
