### PR TITLE
Fixed add local amp sub-generator for windows

### DIFF
--- a/generators/amp-add-local/index.js
+++ b/generators/amp-add-local/index.js
@@ -92,10 +92,10 @@ module.exports = SubGenerator.extend({
     return this.subgeneratorPrompt(this.prompts, '', function (props) {
       this.props = props;
       this.props.warType;
-      if (_.startsWith(this.props.path, 'amps/')) {
+      if (/^amps(?:\/|\\)/.test(this.props.path)) {
         this.props.warType = 'repo';
       }
-      if (_.startsWith(this.props.path, 'amps_share/')) {
+      if (/^amps_share(?:\/|\\)/.test(this.props.path)) {
         this.props.warType = 'share';
       }
       if (this.props.warType === undefined) this.bail = true;


### PR DESCRIPTION
This PR adresses issue #122 
Now we test for both folder separator style `\` and `/` for windows and linux paths.
