### PR TITLE
fix amp-add-local sub-generator for windows #122

### DIFF
--- a/generators/amp-add-local/index.js
+++ b/generators/amp-add-local/index.js
@@ -92,10 +92,10 @@ module.exports = SubGenerator.extend({
     return this.subgeneratorPrompt(this.prompts, '', function (props) {
       this.props = props;
       this.props.warType;
-      if (/^amps(?:\/|\\)/.test(this.props.path)) {
+      if (_.startsWith(this.props.path, path.join('amps', path.sep))) {
         this.props.warType = 'repo';
       }
-      if (/^amps_share(?:\/|\\)/.test(this.props.path)) {
+      if (_.startsWith(this.props.path, path.join('amps_share', path.sep))) {
         this.props.warType = 'share';
       }
       if (this.props.warType === undefined) this.bail = true;


### PR DESCRIPTION
Now we test with os specific folder separator style `\` and `/` accounted for. This is a slight simplification of the solution provided by Younes recently in #123.

fixes #122 
