### PR TITLE
Enable multiple repo/share common amps in one shot

### DIFF
--- a/generators/amp-add-common/index.js
+++ b/generators/amp-add-common/index.js
@@ -14,12 +14,14 @@ const PROJECTS = [
     url: 'http://docs.alfresco.com/aos/concepts/aos-intro.html',
     availability: ['Community'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: 'org.alfresco.aos-module',
-    repoArtifactId: 'alfresco-aos-module',
-    repoVersion: '1.1',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'org.alfresco.aos-module',
+        artifactId: 'alfresco-aos-module',
+        version: '1.1',
+      },
+    ],
+    share: [],
   },
   {
     name: 'AOS Enterprise - Alfresco Office Services (5.1)',
@@ -27,24 +29,34 @@ const PROJECTS = [
     url: 'http://docs.alfresco.com/aos/concepts/aos-intro.html',
     availability: ['Enterprise'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: 'org.alfresco.aos-module',
-    repoArtifactId: 'alfresco-aos-module',
-    repoVersion: '1.1.3',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'org.alfresco.aos-module',
+        artifactId: 'alfresco-aos-module',
+        version: '1.1.3',
+      },
+    ],
+    share: [],
   },
   {
     name: 'Developer Helper',
     description: 'A few simple tools like Open in Node Browser to help developers.',
     url: 'https://github.com/binduwavell/alf-dev-helper',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'net.wavell',
-    repoArtifactId: 'alf-dev-helper-repo-amp',
-    repoVersion: '1.0.0',
-    shareGroupId: 'net.wavell',
-    shareArtifactId: 'alf-dev-helper-share-amp',
-    shareVersion: '1.0.0',
+    repo: [
+      {
+        groupId: 'net.wavell',
+        artifactId: 'alf-dev-helper-repo-amp',
+        version: '1.0.0',
+      },
+    ],
+    share: [
+      {
+        groupId: 'net.wavell',
+        artifactId: 'alf-dev-helper-share-amp',
+        version: '1.0.0',
+      },
+    ],
   },
   {
     name: 'JavaMelody',
@@ -52,24 +64,34 @@ const PROJECTS = [
     url: 'https://github.com/javamelody/alfresco-javamelody',
     availability: ['Community', 'Enterprise'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: 'net.bull.javamelody',
-    repoArtifactId: 'alfresco-javamelody-addon',
-    repoVersion: '1.62.0',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'net.bull.javamelody',
+        artifactId: 'alfresco-javamelody-addon',
+        version: '1.62.0',
+      },
+    ],
+    share: [],
   },
   {
     name: 'JavaScript Console',
     description: 'Enables the execution of arbitrary javascript code in the repository.',
     url: 'https://github.com/share-extras/js-console',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'de.fmaul',
-    repoArtifactId: 'javascript-console-repo',
-    repoVersion: '0.6',
-    shareGroupId: 'de.fmaul',
-    shareArtifactId: 'javascript-console-share',
-    shareVersion: '0.6',
+    repo: [
+      {
+        groupId: 'de.fmaul',
+        artifactId: 'javascript-console-repo',
+        version: '0.6',
+      },
+    ],
+    share: [
+      {
+        groupId: 'de.fmaul',
+        artifactId: 'javascript-console-share',
+        version: '0.6',
+      },
+    ],
   },
   {
     // https://addons.alfresco.com/addons/alfresco-jscript-extensions says com/ent 5.0 & 5.1
@@ -79,12 +101,14 @@ const PROJECTS = [
     url: 'https://github.com/jgoldhammer/alfresco-jscript-extensions',
     availability: ['Community', 'Enterprise'],
     sdkVersions: ['2.0.0', '2.1.0', '2.1.1'],
-    repoGroupId: 'de.jgoldhammer',
-    repoArtifactId: 'alfresco-jscript-extension',
-    repoVersion: '1.3.1',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'de.jgoldhammer',
+        artifactId: 'alfresco-jscript-extension',
+        version: '1.3.1',
+      },
+    ],
+    share: [],
   },
   {
     // https://addons.alfresco.com/addons/alfresco-jscript-extensions says com/ent 5.0 & 5.1
@@ -94,24 +118,34 @@ const PROJECTS = [
     url: 'https://github.com/jgoldhammer/alfresco-jscript-extensions',
     availability: ['Community', 'Enterprise'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: 'de.jgoldhammer',
-    repoArtifactId: 'alfresco-jscript-extension',
-    repoVersion: '1.3.1',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'de.jgoldhammer',
+        artifactId: 'alfresco-jscript-extension',
+        version: '1.3.1',
+      },
+    ],
+    share: [],
   },
   {
     name: 'Order of the Bee - Support Tools',
     description: 'Aims to bring the functionality provided by the Enterprise-only Alfresco Support Tools addon, to the free and open Community Edition of Alfresco.',
     url: 'https://github.com/AFaust/ootbee-support-tools',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'org.orderofthebee.support-tools',
-    repoArtifactId: 'support-tools-repo',
-    repoVersion: '0.0.1.0',
-    shareGroupId: 'org.orderofthebee.support-tools',
-    shareArtifactId: 'support-tools-share',
-    shareVersion: '0.0.1.0',
+    repo: [
+      {
+        groupId: 'org.orderofthebee.support-tools',
+        artifactId: 'support-tools-repo',
+        version: '0.0.1.0',
+      },
+    ],
+    share: [
+      {
+        groupId: 'org.orderofthebee.support-tools',
+        artifactId: 'support-tools-share',
+        version: '0.0.1.0',
+      },
+    ],
   },
   {
     name: 'RM - Records Management (5.0.1)',
@@ -119,12 +153,20 @@ const PROJECTS = [
     url: 'http://docs.alfresco.com/rm2.3/references/whats-new-rm.html',
     sdkVersions: ['2.1.0', '2.1.1'],
     availability: ['Community', 'Enterprise'],
-    repoGroupId: '${alfresco.groupId}',
-    repoArtifactId: 'alfresco-rm',
-    repoVersion: '2.3',
-    shareGroupId: '${alfresco.groupId}',
-    shareArtifactId: 'alfresco-rm-share',
-    shareVersion: '2.3',
+    repo: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm',
+        version: '2.3',
+      },
+    ],
+    share: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm-share',
+        version: '2.3',
+      },
+    ],
   },
   {
     name: 'RM Community - Records Management (5.1)',
@@ -132,12 +174,20 @@ const PROJECTS = [
     url: 'http://docs.alfresco.com/rm/references/whats-new-rm.html',
     availability: ['Community'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: '${alfresco.groupId}',
-    repoArtifactId: 'alfresco-rm-community-repo',
-    repoVersion: '2.5.a',
-    shareGroupId: '${alfresco.groupId}',
-    shareArtifactId: 'alfresco-rm-community-share',
-    shareVersion: '2.5.a',
+    repo: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm-community-repo',
+        version: '2.5.a',
+      },
+    ],
+    share: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm-community-share',
+        version: '2.5.a',
+      },
+    ],
   },
   {
     name: 'RM Enterprise - Records Management (5.1)',
@@ -145,12 +195,20 @@ const PROJECTS = [
     url: 'http://docs.alfresco.com/rm/references/whats-new-rm.html',
     availability: ['Enterprise'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: '${alfresco.groupId}',
-    repoArtifactId: 'alfresco-rm-enterprise-repo',
-    repoVersion: '2.5.0',
-    shareGroupId: '${alfresco.groupId}',
-    shareArtifactId: 'alfresco-rm-enterprise-share',
-    shareVersion: '2.5.0',
+    repo: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm-enterprise-repo',
+        version: '2.5.0',
+      },
+    ],
+    share: [
+      {
+        groupId: '${alfresco.groupId}',
+        artifactId: 'alfresco-rm-enterprise-share',
+        version: '2.5.0',
+      },
+    ],
   },
   {
     // https://addons.alfresco.com/addons/alfresco-share-inbound-calendar-invites says com/ent 5.0 & 5.1
@@ -160,12 +218,14 @@ const PROJECTS = [
     description: 'Gives you the ability to send calendar invitations to an Alfresco Share site. This provides a very basic calendar integration in which users can select which events they create in the corporate email and calendaring system will show up in the Share site calendar.',
     url: 'https://github.com/jpotts/share-inbound-invites',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'com.metaversant',
-    repoArtifactId: 'inbound-invites-repo',
-    repoVersion: '1.1.0',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'inbound-invites-repo',
+        version: '1.1.0',
+      },
+    ],
+    share: [],
   },
   {
     // https://addons.alfresco.com/addons/share-announcements says ent 5.1
@@ -175,12 +235,20 @@ const PROJECTS = [
     description: 'Makes it possible to publish announcements on the Share login page.',
     url: 'https://github.com/jpotts/share-announcements',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'com.metaversant',
-    repoArtifactId: 'share-login-ann-repo',
-    repoVersion: '0.0.2',
-    shareGroupId: 'com.metaversant',
-    shareArtifactId: 'share-login-ann-share',
-    shareVersion: '0.0.2',
+    repo: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'share-login-ann-repo',
+        version: '0.0.2',
+      },
+    ],
+    share: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'share-login-ann-share',
+        version: '0.0.2',
+      },
+    ],
   },
   {
     // https://addons.alfresco.com/addons/share-site-creators says com/ent 5.0 & 5.1
@@ -191,12 +259,20 @@ const PROJECTS = [
     url: 'https://github.com/jpotts/share-site-creators',
     availability: ['Community', 'Enterprise'],
     sdkVersions: ['2.2.0'],
-    repoGroupId: 'com.metaversant',
-    repoArtifactId: 'share-site-creators-repo',
-    repoVersion: '0.0.5',
-    shareGroupId: 'com.metaversant',
-    shareArtifactId: 'share-site-creators-share',
-    shareVersion: '0.0.5',
+    repo: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'share-site-creators-repo',
+        version: '0.0.5',
+      },
+    ],
+    share: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'share-site-creators-share',
+        version: '0.0.5',
+      },
+    ],
   },
   {
     // https://addons.alfresco.com/addons/share-site-space-templates says com/ent 5.0 & 5.1
@@ -206,36 +282,48 @@ const PROJECTS = [
     description: 'Adds the ability to create a default set of folders to an Alfresco Share site by leveraging Space Templates.',
     url: 'https://github.com/jpotts/share-site-space-templates',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'com.metaversant',
-    repoArtifactId: 'share-site-space-templates-repo',
-    repoVersion: '1.1.2',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'com.metaversant',
+        artifactId: 'share-site-space-templates-repo',
+        version: '1.1.2',
+      },
+    ],
+    share: [],
   },
   {
     name: 'Support Tools',
     description: 'Provides the Alfresco admin a set of tools to help troubleshoot performance issues.',
     url: 'https://github.com/Alfresco/alfresco-support-tools',
     availability: ['Enterprise'],
-    repoGroupId: 'org.alfresco.support',
-    repoArtifactId: 'support-tools',
-    repoVersion: '1.11',
-    shareGroupId: undefined,
-    shareArtifactId: undefined,
-    shareVersion: undefined,
+    repo: [
+      {
+        groupId: 'org.alfresco.support',
+        artifactId: 'support-tools',
+        version: '1.11',
+      },
+    ],
+    share: [],
   },
   {
     name: 'Uploader Plus',
     description: 'Enhances the standard Alfresco uploader with a mechanism to prompt the user for content type and metadata during the upload process.',
     url: 'http://softwareloop.com/uploader-plus-an-alfresco-uploader-that-prompts-for-metadata/',
     availability: ['Community', 'Enterprise'],
-    repoGroupId: 'com.softwareloop',
-    repoArtifactId: 'uploader-plus-repo',
-    repoVersion: '1.2',
-    shareGroupId: 'com.softwareloop',
-    shareArtifactId: 'uploader-plus-surf',
-    shareVersion: '1.2',
+    repo: [
+      {
+        groupId: 'com.softwareloop',
+        artifactId: 'uploader-plus-repo',
+        version: '1.2',
+      },
+    ],
+    share: [
+      {
+        groupId: 'com.softwareloop',
+        artifactId: 'uploader-plus-surf',
+        version: '1.2',
+      },
+    ],
   },
 ];
 
@@ -256,7 +344,7 @@ class AmpAddCommonSubGenerator extends SubGenerator {
         if (sdkVersion === undefined) return true;
         return (project.hasOwnProperty('sdkVersions') ? project.sdkVersions.indexOf(sdkVersion) > -1 : true);
       })
-      .filter(isNotAppliedFactory(this.moduleRegistry));
+      .filter(project => !isApplied(project, this.moduleRegistry));
 
     if (projects.length === 0) {
       this.out.info('You are already using all of the available common amps');
@@ -300,59 +388,65 @@ class AmpAddCommonSubGenerator extends SubGenerator {
           return (props.projectNames.indexOf(project.name) > -1);
         });
       projects.forEach(project => {
-        if (project.repoGroupId) {
-          debug('attempting to compose %s to add %s to the repo', NAMESPACE_REMOTE, project.repoArtifactId);
-          this.composeWith(require.resolve('../amp-add-remote'),
-            {
-              war: 'repo',
-              'group-id': project.repoGroupId,
-              'artifact-id': project.repoArtifactId,
-              'amp-version': project.repoVersion,
-              _moduleRegistry: this.moduleRegistry,
-              _modules: this.modules,
-              _moduleManager: this.moduleManager,
-            });
+        if (project.repo && project.repo.length > 0) {
+          project.repo.forEach(repoProject => {
+            if (getRepoAmp(repoProject, this.moduleRegistry) === undefined) {
+              debug('attempting to compose %s to add %s to the repo', NAMESPACE_REMOTE, repoProject.artifactId);
+              this.composeWith(require.resolve('../amp-add-remote'),
+                {
+                  'war': 'repo',
+                  'group-id': repoProject.groupId,
+                  'artifact-id': repoProject.artifactId,
+                  'amp-version': repoProject.version,
+                  _moduleRegistry: this.moduleRegistry,
+                  _modules: this.modules,
+                  _moduleManager: this.moduleManager,
+                });
+            }
+          });
         }
-        if (project.shareGroupId) {
-          debug('attempting to compose %s to add %s to the share', NAMESPACE_REMOTE, project.shareArtifactId);
-          this.composeWith(require.resolve('../amp-add-remote'),
-            {
-              war: 'share',
-              'group-id': project.shareGroupId,
-              'artifact-id': project.shareArtifactId,
-              'amp-version': project.shareVersion,
-              _moduleRegistry: this.moduleRegistry,
-              _modules: this.modules,
-              _moduleManager: this.moduleManager,
-            });
+        if (project.share && project.share.length > 0) {
+          project.share.forEach(shareProject => {
+            if (getShareAmp(shareProject, this.moduleRegistry) === undefined) {
+              debug('attempting to compose %s to add %s to the share', NAMESPACE_REMOTE, shareProject.artifactId);
+              this.composeWith(require.resolve('../amp-add-remote'),
+                {
+                  'war': 'share',
+                  'group-id': shareProject.groupId,
+                  'artifact-id': shareProject.artifactId,
+                  'amp-version': shareProject.version,
+                  _moduleRegistry: this.moduleRegistry,
+                  _modules: this.modules,
+                  _moduleManager: this.moduleManager,
+                });
+            }
+          });
         }
       });
     });
   }
 };
 
-function isNotApplied (project, moduleRegistry) {
-  let applied = false;
-  if (project.repoGroupId) {
-    const repo = moduleRegistry.findModule(project.repoGroupId, project.repoArtifactId, project.repoVersion, 'amp', 'repo', 'remote');
-    if (repo !== undefined) {
-      applied = true;
-    }
+function isApplied (project, moduleRegistry) {
+  if (project.repo && project.repo.length > 0 && getRepoAmp(project.repo[0], moduleRegistry) !== undefined) {
+    return true;
   }
-  if (!applied && project.shareGroupId) {
-    const share = moduleRegistry.findModule(project.shareGroupId, project.shareArtifactId, project.shareVersion, 'amp', 'share', 'remote');
-    if (share !== undefined) {
-      applied = true;
-    }
+  if (project.share && project.share.length > 0 && getShareAmp(project.share[0], moduleRegistry) !== undefined) {
+    return true;
   }
-
-  return !applied;
+  return false;
 }
 
-function isNotAppliedFactory (moduleRegistry) {
-  return project => {
-    return isNotApplied(project, moduleRegistry);
-  };
+function getRepoAmp (repoAmp, moduleRegistry) {
+  const module = moduleRegistry.findModule(repoAmp.groupId, repoAmp.artifactId, repoAmp.version, 'amp', 'repo', 'remote');
+  debug('Found module %j', module);
+  return module;
+}
+
+function getShareAmp (shareAmp, moduleRegistry) {
+  const module = moduleRegistry.findModule(shareAmp.groupId, shareAmp.artifactId, shareAmp.version, 'amp', 'share', 'remote');
+  debug('Found module %j', module);
+  return module;
 }
 
 module.exports = AmpAddCommonSubGenerator;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Yeoman generator",
   "license": "Apache-2.0",
   "main": "app/index.js",


### PR DESCRIPTION
amp-add-common can add one share amp and one repo amp per line item, this update allows a single line item to install zero to many amps of each kind.

We may need to install multiple AMPs for RM enterprise. Similarly we will have to install multiple AMPs for care4alf (care4alf and Alfresco Dynamic Extensions.)

Resolves #118