### PR TITLE
BaseGenerator now uses CLIGenerator

### DIFF
--- a/generators/base-generator.js
+++ b/generators/base-generator.js
@@ -1,64 +1,17 @@
 'use strict';
-const _ = require('lodash');
-const chalk = require('chalk');
-const debug = require('debug')('generator-alfresco:base-generator');
-const Generator = require('yeoman-generator');
+const CLIGenerator = require('generator-alfresco-common').cli_generator;
 
 /**
  * Base class for a yeoman generator in the generator-alfresco project. This
  * class provides some common things like our output handling module,
  * the SDK version for the main project and the module registry and manager.
  *
- * We will create / wrap a when function in order to perform bail checking.
- *
- * In contrast to a regular sub/generator we expect the prompts to be defined in
- * the constructor. For the setupArgumentsAndOptions method to be called in the
- * constructor (if you want option or argument handling) and for the prompting to
- * use this.subgeneratorPrompt() instead of this.prompt() in the prompting
- * lifecycle function.
- *
- * You may add argument and/or option properties to each prompt definitions. The
- * setupArgumentsAndOptions function pulls these out and registers them
- * appropriately. The value for each of these properties is { name: 'name',
- * config: { } }. The name is passed as * the first argument to this.argument()/
- * this.option() respectively and the config object is passed as the second
- * argument.
- *
- * If a prompt defines a property named commonFilter with a function for the value
- * and no filter property is defined explicitly, we'll use the commonFilter value
- * to create the filter property.
- *
- * If the option property is specified, we'll create a when function that uses the
- * commonFilter function to skip the prompt if the option is provided and valid.
- *
- * If there is no validate property specified, we'll produce one using the
- * commonFilter. An optinal invalidMessage property may be specified to control
- * how the generated validate function reports invalid input. The invalidMessage
- * property may be a string or a function that takes the user input as the only
- * argument. If invalidMessage is not provided then a basic message will be
- * generated.
- *
- * A new valueRequired boolean property may be specified in a prompt. This will
- * be used to inject a check in our generated prompt completion function prior
- * to calling the user supplied donePromptingFunc in subGeneratorPrompt. The
- * reason we do this has to do with how yeoman tests work with options and
- * prompts. Specifically we can't expect the same set of prompt functions
- * around validation and filtering to be called for the tests. As such if we
- * have any required inputs a test may attempt to run without required data
- * unless we have this check.
- *
- * IN THE FUTURE, we may be able to use valueRequired to create a batch mode
- * where optional items don't need to be specified when using arguments /
- * options to streamline completely command line driven usage. FUTURE
- *
- * In order to reduce boilerplate, each function we create will be bound to this
- * yeoman generator instance automatically.
+ * Lots of info in cli-generator.js code!
  */
-class BaseGenerator extends Generator {
+class BaseGenerator extends CLIGenerator {
   constructor (args, opts) {
     super(args, opts);
 
-    this.bail = false;
     this.out = require('generator-alfresco-common').generator_output(this);
     this.sdkVersions = require('./common/sdk-versions.js');
     this.sdk = this.sdkVersions[this.config.get('sdkVersion')];
@@ -67,117 +20,6 @@ class BaseGenerator extends Generator {
     this.moduleRegistry = this.options._moduleRegistry || require('generator-alfresco-common').alfresco_module_registry(this);
     this.modules = this.options._modules || this.moduleRegistry.getNamedModules();
     this.moduleManager = this.options._moduleManager || require('./common/alfresco-module-manager.js')(this);
-    this.answerOverrides = {};
-  }
-
-  setupArgumentsAndOptions (prompts) {
-    prompts.forEach(prompt => {
-      if (prompt.hasOwnProperty('argument')) {
-        debug('Adding argument %s with config %j', prompt.argument.name, prompt.argument.config);
-        this.argument(prompt.argument.name, prompt.argument.config);
-      }
-      if (prompt.hasOwnProperty('option')) {
-        debug('Adding option %s with config %j', prompt.option.name, prompt.option.config);
-        this.option(prompt.option.name, prompt.option.config);
-      }
-    });
-  }
-
-  subgeneratorPrompt (prompts, desc, donePromptingFunc) {
-    // ==== PROMPT EXTENSIONS ====
-    this.processedPrompts = prompts.map(prompt => {
-      const newPrompt = _.assign({}, prompt);
-      const oldWhen = prompt.when;
-      newPrompt.when = props => {
-        debug('Synthetic when() logic');
-        if (this.bail) return false;
-        if (prompt.hasOwnProperty('commonFilter') && _.isFunction(prompt.commonFilter)
-          && prompt.hasOwnProperty('name') && (
-            (prompt.hasOwnProperty('option') && prompt.option.hasOwnProperty('name'))
-            || (prompt.hasOwnProperty('argument') && prompt.argument.hasOwnProperty('name'))
-          )
-        ) {
-          let cliName;
-          let cliValue;
-          if (prompt.hasOwnProperty('option') && prompt.option.hasOwnProperty('name')) {
-            cliName = prompt.option.name;
-            cliValue = this.options[prompt.option.name];
-            debug('Calling commonFilter(%s) for option: %s', cliValue, cliName);
-          } else {
-            cliName = prompt.argument.name;
-            cliValue = this.options[prompt.argument.name];
-            debug('Calling commonFilter(%s) for argument: %s', cliValue, cliName);
-          }
-          const v = prompt.commonFilter.call(this, cliValue);
-          if (undefined !== v) {
-            this.answerOverrides[prompt.name] = v;
-            this.out.info('Value for ' + cliName + ' set from command line: ' + chalk.reset.dim.cyan(v));
-            return false;
-          }
-        }
-        if (_.isBoolean(oldWhen)) {
-          debug('Returning when=%s via value provided in prompt %s', oldWhen, prompt.name);
-          return oldWhen;
-        }
-        if (_.isFunction(oldWhen)) {
-          const retv = oldWhen.call(this, props);
-          debug('Returning when(%s)=%s via function provided in prompt: %s', JSON.stringify(props), retv, prompt.name);
-          return retv;
-        }
-        return true;
-      };
-      if (prompt.hasOwnProperty('commonFilter') && _.isFunction(prompt.commonFilter)) {
-        if (!prompt.hasOwnProperty('filter')) {
-          newPrompt.filter = input => {
-            debug('Using commonFilter(%s) for filter', input);
-            return prompt.commonFilter.call(this, input);
-          };
-        }
-        if (!prompt.hasOwnProperty('validate') && prompt.hasOwnProperty('name')) {
-          newPrompt.validate = input => {
-            debug('Using commonFilter(%s) for validate', input);
-            const required = prompt.valueRequired;
-            let msg = 'The ' + (required ? 'required ' : '') + chalk.yellow(prompt.name) + ' value '
-              + (required ? 'is missing or invalid' : 'is invalid');
-            if (prompt.hasOwnProperty('invalidMessage')) {
-              if (_.isFunction(prompt.invalidMessage)) {
-                msg = prompt.invalidMessage.call(this, input);
-              }
-              if (_.isString(prompt.invalidMessage)) {
-                msg = prompt.invalidMessage;
-              }
-            }
-            return (prompt.commonFilter.call(this, input) !== undefined ? true : msg);
-          };
-        }
-      }
-      return newPrompt;
-    });
-
-    // ==== NOW DO THE ACTUAL PROMPTING ====
-    return this.prompt(this.processedPrompts).then(props => {
-      const combinedProps = {};
-      if (!this.bail) {
-        _.assign(combinedProps, this.answerOverrides);
-        _.assign(combinedProps, props);
-        this.processedPrompts.forEach(promptItem => {
-          const name = promptItem.name;
-          const required = promptItem.valueRequired;
-          if (name && required) {
-            debug('Required check for %s which is %s and has value %s', name, (required ? 'required' : 'not required'), combinedProps[name]);
-            if (undefined === combinedProps[name]) {
-              this.out.error('At least one required properties not set: ' + name);
-              this.bail = true;
-            }
-          }
-        });
-      }
-      if (!this.bail && donePromptingFunc) {
-        debug('calling user supplied done prompting function');
-        donePromptingFunc.call(this, combinedProps);
-        debug('completed user supplied done prompting function');
-      }
-    });
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1805,9 +1805,9 @@
       "dev": true
     },
     "generator-alfresco-common": {
-      "version": "0.9.24",
-      "resolved": "https://registry.npmjs.org/generator-alfresco-common/-/generator-alfresco-common-0.9.24.tgz",
-      "integrity": "sha512-RMdWTAGd2gzCY12iPut1xloTOkdKU5ZbpmuFEDxnYik8qzOfmyW5Y9Br50bKCUyHErPFqE9VEWIm18JHo0KoBw==",
+      "version": "0.9.25",
+      "resolved": "https://registry.npmjs.org/generator-alfresco-common/-/generator-alfresco-common-0.9.25.tgz",
+      "integrity": "sha512-CVAjwzBNvWgayEU0S2FOAtK3cJkoFZvwSvQdHVzXyUCQCrMds1fVixef8vL5ibbCKxjhwkG1Er4giU/W8qm0/Q==",
       "requires": {
         "chalk": "2.3.0",
         "cross-spawn": "5.1.0",
@@ -1826,7 +1826,8 @@
         "window-size": "1.1.0",
         "wrap-ansi": "3.0.1",
         "xmldom": "0.1.27",
-        "xpath": "0.0.27"
+        "xpath": "0.0.27",
+        "yeoman-generator": "2.0.2"
       }
     },
     "get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "Yeoman generator",
   "license": "Apache-2.0",
   "main": "app/index.js",
@@ -28,7 +28,7 @@
     "ascii-table": "0.0.9",
     "chalk": "2.3.0",
     "debug": "3.1.0",
-    "generator-alfresco-common": "0.9.24",
+    "generator-alfresco-common": "0.9.25",
     "lodash": "4.17.4",
     "mem-fs-editor": "3.0.2",
     "rmdir": "1.2.0",


### PR DESCRIPTION
### CHECKLIST

We will not consider a PR untill all of the following items are checked off--thank you!

- [X] There aren't existing pull requests attempting to address the issue mentioned here
- [X] Submission developed in a feature branch--not master
- [X] Confirmed there are no outstanding `npm run eslint` issues
- [X] Added/updated tests for new/changed code
- [X] Appropriate coverage validated with `npm run cover:local`
- [X] All `npm test` passes without any issues

### CONVINCING DESCRIPTION

Was discussing our extensions to yeoman generator that add support for specifying options and arguments in the prompt definition and he was interested in using these for the ADF yeoman generators. As such we extracted most of the logic from BaseGenerator into CLIGenerator in the generator-alfresco-common project. This commit removes the common code from BaseGenerator and extends CLIGenerator instead.