### PR TITLE
Amp to module rename fixup

### DIFF
--- a/generators/source-selecting-subgenerator.js
+++ b/generators/source-selecting-subgenerator.js
@@ -54,7 +54,7 @@ class SourceSelectingSubGenearator extends SubGenerator {
           }
           // Error out if there are no matching modules
           if (this.modules.length === 0) {
-            this.out.error('No source modules available matching your criteria. Try creating a source module with ' + chalk.bold.green('"yo alfresco:amp"') + ' before using this sub-generator.');
+            this.out.error('No source modules available matching your criteria. Try creating a source module with ' + chalk.bold.green('"yo alfresco:module"') + ' before using this sub-generator.');
             this.targetModule = true;
             this.bail = true;
             return false;

--- a/generators/webscript/USAGE
+++ b/generators/webscript/USAGE
@@ -1,6 +1,6 @@
 Notes:
   The module-path option should be specified as a relative path from the root of
   your project to the folder that contains the pom.xml file for your module. Say
-  you used 'yo alfresco:amp' to create a repository module called
+  you used 'yo alfresco:module' to create a repository module called
   client-repo-amp directly in the customizations folder. In this case you would
   provide the value 'customizations/client-repo-amp'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-alfresco",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Yeoman generator",
   "license": "Apache-2.0",
   "main": "app/index.js",


### PR DESCRIPTION
There were a couple of places where 'yo alfresco:amp' was still referenced, when 'yo alfresco:module' should have been referenced. This was in documentation and an informational message output by sub-generators based on the source-selecting sub generator.